### PR TITLE
Fix truncated output from fwup on error

### DIFF
--- a/lib/nerves_firmware_ssh/fwup.ex
+++ b/lib/nerves_firmware_ssh/fwup.ex
@@ -17,9 +17,12 @@ defmodule Nerves.Firmware.SSH.Fwup do
     devpath = Nerves.Runtime.KV.get("nerves_fw_devpath") || "/dev/mmcblk0"
     task = "upgrade"
 
+    args = if supports_handshake(), do: ["--exit-handshake"], else: []
+    args = args ++ ["--apply", "--no-unmount", "-d", devpath, "--task", task]
+
     port =
       Port.open({:spawn_executable, fwup}, [
-        {:args, ["--apply", "--no-unmount", "-d", devpath, "--task", task]},
+        {:args, args},
         :use_stdio,
         :binary,
         :exit_status
@@ -28,19 +31,69 @@ defmodule Nerves.Firmware.SSH.Fwup do
     {:ok, %{port: port, cm: cm}}
   end
 
+  def handle_call(_cmd, _from, %{port: nil} = state) do
+    # In the process of closing down, so just ignore these.
+    {:reply, :error, state}
+  end
+
   def handle_call({:send, chunk}, _from, state) do
-    true = Port.command(state.port, chunk)
-    {:reply, :ok, state}
+    # Since fwup may be slower than ssh, we need to provide backpressure
+    # here. It's tricky since `Port.command/2` is the only way to send
+    # bytes to fwup synchronously, but it's possible for fwup to error
+    # out when it's sending. If fwup errors out, then we need to make
+    # sure that a message gets back to the user for what happened.
+    # `Port.command/2` exits on error (it will be an :epipe error).
+    # Therefore we start a new process to call `Port.command/2` while
+    # we continue to handle responses. We also trap_exit to get messages
+    # when the port the Task exit.
+    result =
+      try do
+        Port.command(state.port, chunk)
+        :ok
+      rescue
+        ArgumentError ->
+          Logger.info("Port.command ArgumentError race condition detected and handled")
+          :error
+      end
+
+    {:reply, result, state}
   end
 
-  def handle_info({_port, {:data, response}}, state) do
-    :ok = :ssh_channel.cast(state.cm, {:fwup_data, response})
+  def handle_info({port, {:data, response}}, %{port: port} = state) do
+    trimmed_response =
+      if String.contains?(response, "\x1a") do
+        # fwup says that it's going to exit by sending a CTRL+Z (0x1a)
+        # The CTRL+Z is the very last character that will ever be
+        # received over the port, so handshake by closing the port.
+        send(port, {self(), :close})
+        String.trim_trailing(response, "\x1a")
+      else
+        response
+      end
+    :ok = :ssh_channel.cast(state.cm, {:fwup_data, trimmed_response})
     {:noreply, state}
   end
 
-  def handle_info({_port, {:exit_status, status}}, state) do
-    Logger.info("fwup exited with status #{status}")
-    :ok = :ssh_channel.cast(state.cm, {:fwup_exit, status})
-    {:noreply, state}
+  def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
+    Logger.info("fwup exited with status #{status} without handshaking")
+    :ssh_channel.cast(state.cm, {:fwup_exit, status})
+    {:noreply, %{state | port: nil}}
+  end
+
+  def handle_info({port, :closed}, %{port: port} = state) do
+    Logger.info("fwup port was closed")
+    :ssh_channel.cast(state.cm, {:fwup_exit, 0})
+    {:noreply, %{state | port: nil}}
+  end
+
+  defp supports_handshake() do
+    Version.match?(fwup_version(), "> 0.17.0")
+  end
+
+  defp fwup_version() do
+    {version_str, 0} = System.cmd("fwup", ["--version"])
+    version_str
+    |> String.trim()
+    |> Version.parse!()
   end
 end

--- a/lib/nerves_firmware_ssh/handler.ex
+++ b/lib/nerves_firmware_ssh/handler.ex
@@ -114,6 +114,11 @@ defmodule Nerves.Firmware.SSH.Handler do
     {:ok, new_state}
   end
 
+  defp process_message(:wait_for_fwup_error, _data, state) do
+    # Just disgard anything we get
+    {:ok, state}
+  end
+
   defp run_commands([], _data, state) do
     :ssh_connection.send_eof(state.cm, state.id)
     {:stop, state.id, state}
@@ -125,19 +130,30 @@ defmodule Nerves.Firmware.SSH.Handler do
     bytes_left = count - state.bytes_processed
     bytes_to_process = min(bytes_left, byte_size(data))
     <<for_fwup::binary-size(bytes_to_process), leftover::binary>> = data
-    :ok = Fwup.send_chunk(state.fwup, for_fwup)
-
     new_bytes_processed = state.bytes_processed + bytes_to_process
 
-    if new_bytes_processed == count do
-      new_state = %{
-        state | state: :wait_for_fwup, buffer: leftover, commands: rest, bytes_processed: 0
-      }
+    case {Fwup.send_chunk(state.fwup, for_fwup), new_bytes_processed} do
+      {:ok, ^count} ->
+        # Done
+        new_state = %{
+          state | state: :wait_for_fwup, buffer: leftover, commands: rest, bytes_processed: 0
+        }
 
-      {:ok, new_state}
-    else
-      new_state = %{state | bytes_processed: new_bytes_processed}
-      {:ok, new_state}
+        {:ok, new_state}
+
+      {:ok, _} ->
+        # More left
+        new_state = %{state | bytes_processed: new_bytes_processed}
+        {:ok, new_state}
+
+      _ ->
+        # Error - need to wait for fwup to exit so that we can
+        # report back anything that it may say
+        new_state = %{
+          state | state: :wait_for_fwup_error, buffer: <<>>, commands: [], bytes_processed: 0
+        }
+
+        {:ok, new_state}
     end
   end
 
@@ -150,7 +166,8 @@ defmodule Nerves.Firmware.SSH.Handler do
     run_commands(rest, data, new_state)
   end
 
-  defp maybe_fwup(%{fwup: fwup} = state) when fwup == nil do
+  defp maybe_fwup(%{fwup: nil} = state) do
+    Logger.debug("nerves_firmware_ssh: starting fwup...\n")
     :ssh_connection.send(state.cm, state.id, "Running fwup...\n")
     {:ok, new_fwup} = Fwup.start_link(self())
     %{state | fwup: new_fwup}

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,11 @@ defmodule Nerves.Firmware.SSH.Mixfile do
   end
 
   defp deps() do
-    [{:nerves_runtime, "~> 0.4"}, {:ex_doc, "~> 0.11", only: :dev}]
+    [
+      {:nerves_runtime, "~> 0.4"},
+      {:ex_doc, "~> 0.11", only: :dev},
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false}
+    ]
   end
 
   defp package() do

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+%{"dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_runtime": {:hex, :nerves_runtime, "0.4.2", "aff110c7ca2f424bcbdc869f0ef9881ccfdd3c2c2e21a59d1343f3195d1adf8b", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:system_registry, "~> 0.3", [hex: :system_registry, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -10,6 +10,10 @@ defmodule CommandTest do
     assert Command.parse("reboot\nleftovers") == {:ok, [:reboot], "leftovers"}
   end
 
+  test "that an invalid command errors" do
+    assert Command.parse("rebot\nleftovers") == {:error, :invalid_command}
+  end
+
   test "that multiple commands parse" do
     assert Command.parse("fwup:123,reboot\nleftovers") == {
              :ok,


### PR DESCRIPTION
The main change is to add a handshake step with fwup to ensure that the final error message is always received by the user. There's a race condition with Erlang ports when Erlang processes are actively sending to them and the pipe breaks to the OS process. That causes the cleanup to happen quickly even if some data is en route to Erlang from `fwup`. The handshake ensures that Erlang receives everything before `fwup` exits. This only works in `fwup` 0.17.0 and later, but there's a check so that if you're running with an earlier version of `fwup`, the handshake isn't used. The bug exists in those versions, but at least you can still run firmware updates.