### PR TITLE
Change some docs to point to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First, add `nerves_firmware_ssh` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:nerves_firmware_ssh, github: "fhunleth/nerves_firmware_ssh"}]
+  [{:nerves_firmware_ssh, "~> 0.2"}]
 end
 ```
 
@@ -106,7 +106,7 @@ If you're not able to connect, try the following:
 4. Add `:runtime_tools` to the `:extra_applications` key in your `mix.exs` and
    run `:ssh_dbg.messages()` on the target and try to connect. You should get
    some diagnostic data from the Erlang `:ssh` application that may help.
-5. File an [issue](https://github.com/fhunleth/nerves_firmware_ssh/issues/new)
+5. File an [issue](https://github.com/nerves-project/nerves_firmware_ssh/issues/new)
    or try the `#nerves` channel on the [Elixir Slack](https://elixir-slackin.herokuapp.com/).
 
 ### Oops, I have the wrong keys on the device

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Nerves.Firmware.SSH.Mixfile do
     [
       maintainers: ["Frank Hunleth"],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/fhunleth/nerves_firmware_ssh"}
+      links: %{"GitHub" => "https://github.com/nerves-project/nerves_firmware_ssh"}
     ]
   end
 end

--- a/priv/templates/script.upload.eex
+++ b/priv/templates/script.upload.eex
@@ -16,8 +16,9 @@
 #   UserKnownHostsFile /dev/null
 #   StrictHostKeyChecking no
 #
-# Feel free to copy this script whereever is convenient. The original
-# is at https://github.com/fhunleth/nerves_firmware_ssh/blob/master/upload.sh
+# Feel free to copy this script whereever is convenient. The template
+# is at
+# https://github.com/nerves-project/nerves_firmware_ssh/blob/master/priv/templates/script.upload.eex
 #
 
 set -e


### PR DESCRIPTION
Changing some stuff from fhunleth -> nerves-project, and also updating the readme to point to the hex.pm version of this package instead of directly at github.

If this isn't right, feel free to close.