### PR TITLE
ERL-469 has been fixed so remove workaround

### DIFF
--- a/priv/templates/script.upload.eex
+++ b/priv/templates/script.upload.eex
@@ -54,9 +54,6 @@ fi
 
 echo "Uploading $FILENAME to $DESTINATION..."
 
-# Workaround for https://bugs.erlang.org/browse/ERL-469
-unset SSH_AUTH_SOCK
-
 # Don't fall back to asking for passwords, since that won't work
 # and it's easy to misread the message thinking that it's asking
 # for the private key password


### PR DESCRIPTION
This requires Erlang 20.2.1 and later. Nerves has been shipping with
that for a few months so hopefully most people have upgraded by now.
This lets you use ssh-agent now and is super nice.