### PR TITLE
Add information to the error message for the firmware.push task

### DIFF
--- a/lib/mix/tasks/firmware.push.ex
+++ b/lib/mix/tasks/firmware.push.ex
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Firmware.Push do
     end
 
     if length(args) != 1 do
-      Mix.raise("mix firmware.push expects a target IP address or name")
+      Mix.raise(target_ip_address_or_name_msg())
     end
 
     [ip] = args
@@ -171,5 +171,18 @@ defmodule Mix.Tasks.Firmware.Push do
       timeout ->
         wait_for_complete(connection_ref, channel_id, chunks)
     end
+  end
+
+  defp target_ip_address_or_name_msg() do
+    ~S"""
+    mix firmware.push expects a target IP address or name
+
+    If you have a name configured, you should pass in only the domain name.
+
+    Example:
+
+      Given the name is `target01@nerves.local`, you should use:
+      `mix firmware.push nerves.local`
+    """
   end
 end


### PR DESCRIPTION
@fhunleth I was using the `mix firmware.push` task and there was a little gotcha when passing in a `name`. The name is not the full name, it is only the mdns name that the target has configured. So, I added some info regarding that to the error message.

But... I just saw that you have plans of removing/refactoring the task itself (https://github.com/nerves-project/nerves_firmware_ssh/pull/16).

It's here if you want it, it took me some time to research about it. No hard feelings if you close it.