### PR TITLE
Add missing exit_status(0)

### DIFF
--- a/lib/nerves_firmware_ssh/handler.ex
+++ b/lib/nerves_firmware_ssh/handler.ex
@@ -121,6 +121,7 @@ defmodule Nerves.Firmware.SSH.Handler do
 
   defp run_commands([], _data, state) do
     :ssh_connection.send_eof(state.cm, state.id)
+    :ssh_connection.exit_status(state.cm, state.id, 0)
     {:stop, state.id, state}
   end
 


### PR DESCRIPTION
This makes the return code from the calling `ssh` be 0 on success.
Previously, the ssh connection would be terminated without sending a
return code and the client would return a 255.

See https://elixirforum.com/t/using-default-firmware-gen-script-exits-255-even-though-upload-is-successful/15677