### PR TITLE
 Turn off the Erlang shell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,24 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.6.6
+      - image: circleci/elixir:1.7.4
     working_directory: ~/repo
-    environment:
-      MIX_ENV: test
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-dependency-cache-{{ checksum "mix.lock" }}
       - run: sudo apt update -qq && sudo apt install libmnl-dev -qq
-      - run: mix local.hex --force && mix local.rebar --force
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
       - run: mix deps.get --only test
       - run: mix test
+      - run: mix hex.build
+      - run: mix docs
+      - run: mix dialyzer --halt-exit-status
       - run: mix format --check-formatted
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum "mix.lock" }}
+          paths:
+            - _build
+            - deps

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,7 @@
+use Mix.Config
+
+config :nerves_runtime,
+  target: "host"
+
+config :nerves_firmware_ssh,
+  authorized_keys: []

--- a/lib/mix/tasks/firmware.gen.script.ex
+++ b/lib/mix/tasks/firmware.gen.script.ex
@@ -13,8 +13,8 @@ defmodule Mix.Tasks.Firmware.Gen.Script do
 
   It saves the script to #{@script_name}.
   """
-
-  def run(_) do
+  @spec run(keyword()) :: :ok
+  def run(_args) do
     upload_script_contents =
       Application.app_dir(:nerves_firmware_ssh, "priv/templates/script.upload.eex")
       |> EEx.eval_file([])

--- a/lib/mix/tasks/firmware.push.ex
+++ b/lib/mix/tasks/firmware.push.ex
@@ -10,6 +10,7 @@ defmodule Mix.Tasks.Firmware.Push do
   until `mix firmware.push` can be properly fixed.
   """
 
+  @spec run(keyword()) :: no_return()
   def run(_args) do
     Mix.raise("""
     Please use `mix firmware.gen.script` and run the shell script

--- a/lib/nerves_firmware_ssh/application.ex
+++ b/lib/nerves_firmware_ssh/application.ex
@@ -33,6 +33,7 @@ defmodule Nerves.Firmware.SSH.Application do
         {:id_string, :random},
         {:key_cb, {Nerves.Firmware.SSH.Keys, cb_opts}},
         {:system_dir, system_dir()},
+        {:ssh_cli, :no_cli},
         {:subsystems, [{'nerves_firmware_ssh', {Nerves.Firmware.SSH.Handler, []}}]}
       ])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Nerves.Firmware.SSH.Mixfile do
   defp deps() do
     [
       {:nerves_runtime, "~> 0.4"},
-      {:ex_doc, "~> 0.18.0", only: [:dev, :test], runtime: false},
+      {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule Nerves.Firmware.SSH.Mixfile do
       docs: docs(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      dialyzer: [plt_add_apps: [:mix, :eex]]
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,11 @@
 %{
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "nerves_runtime": {:hex, :nerves_runtime, "0.6.5", "7b43e555be567252b60fd927efe295881e79328fc19b03a1b69dbe4fbf78249f", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:system_registry, "~> 0.5", [hex: :system_registry, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nerves_runtime": {:hex, :nerves_runtime, "0.8.0", "9657810438a346122a15762deafc4a7adda4aeb545c57681b5aed0fb0f635617", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:system_registry, "~> 0.5", [hex: :system_registry, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
   "system_registry": {:hex, :system_registry, "0.8.0", "09240347628b001433d18279a2759ef7237ba7361239890d8c599cca9a2fbbc2", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
If you try to ssh into the firmware update port, you'll get an Erlang
shell. Turn that part off.

This is intended to be merged after #28.