### PR TITLE
Look for the .fw file if the mix.exs isn't upgraded

### DIFF
--- a/priv/templates/script.upload.eex
+++ b/priv/templates/script.upload.eex
@@ -44,11 +44,15 @@ help() {
 if [ -z "$FILENAME" ]; then
     FIRMWARE_PATH="./_build/${MIX_TARGET}_${MIX_ENV}/nerves/images"
     if [ ! -d "$FIRMWARE_PATH" ]; then
-        # Try the pre-Nerves 1.4 path
-        FIRMWARE_PATH="./_build/${MIX_TARGET}/${MIX_ENV}/nerves/images"
+        # Try the Nerves 1.4 path if the user hasn't upgraded their mix.exs
+        FIRMWARE_PATH="./_build/${MIX_TARGET}/${MIX_TARGET}_${MIX_ENV}/nerves/images"
         if [ ! -d "$FIRMWARE_PATH" ]; then
-            echo "Can't find the build products. Specify path to .fw file or try running 'mix firmware'"
-            exit 1
+            # Try the pre-Nerves 1.4 path
+            FIRMWARE_PATH="./_build/${MIX_TARGET}/${MIX_ENV}/nerves/images"
+            if [ ! -d "$FIRMWARE_PATH" ]; then
+                echo "Can't find the build products. Specify path to .fw file or try running 'mix firmware'"
+                exit 1
+            fi
         fi
     fi
 


### PR DESCRIPTION
This handles the case where a user is using the new Elixir 1.8 updates,
but hasn't updated their mix.exs.