### PR TITLE
Fix fwup process not exiting when update is cancelled by user

### DIFF
--- a/lib/nerves_firmware_ssh/fwup.ex
+++ b/lib/nerves_firmware_ssh/fwup.ex
@@ -95,7 +95,9 @@ defmodule Nerves.Firmware.SSH.Fwup do
     {:noreply, %{state | port: nil}}
   end
 
-  def handle_info({:DOWN, _, :process, cm, reason}, %{cm: cm} = state) do
+  def handle_info({:DOWN, _, :process, cm, reason}, %{cm: cm, port: port} = state) do
+    _ = Logger.info("firmware ssh handler exited before fwup could finish")
+    send(port, {self(), :close})
     {:stop, :normal, state}
   end
 

--- a/lib/nerves_firmware_ssh/fwup.ex
+++ b/lib/nerves_firmware_ssh/fwup.ex
@@ -95,7 +95,7 @@ defmodule Nerves.Firmware.SSH.Fwup do
     {:noreply, %{state | port: nil}}
   end
 
-  def handle_info({:DOWN, _, :process, cm, reason}, %{cm: cm, port: port} = state) do
+  def handle_info({:DOWN, _, :process, cm, _reason}, %{cm: cm, port: port} = state) do
     _ = Logger.info("firmware ssh handler exited before fwup could finish")
     send(port, {self(), :close})
     {:stop, :normal, state}

--- a/lib/nerves_firmware_ssh/fwup.ex
+++ b/lib/nerves_firmware_ssh/fwup.ex
@@ -13,6 +13,7 @@ defmodule Nerves.Firmware.SSH.Fwup do
   end
 
   def init([cm]) do
+    Process.monitor(cm)
     fwup = System.find_executable("fwup")
     devpath = Nerves.Runtime.KV.get("nerves_fw_devpath") || "/dev/mmcblk0"
     task = "upgrade"
@@ -92,6 +93,10 @@ defmodule Nerves.Firmware.SSH.Fwup do
     _ = Logger.info("fwup port was closed")
     :ssh_channel.cast(state.cm, {:fwup_exit, 0})
     {:noreply, %{state | port: nil}}
+  end
+
+  def handle_info({:DOWN, _, :process, cm, reason}, %{cm: cm} = state) do
+    {:stop, :normal, state}
   end
 
   defp supports_handshake() do


### PR DESCRIPTION
This fixes #44 by ensuring the Fwup process always exits when the SSH handler exits. Since this isn't happening, even though the processes are linked, I guess the handler exits with reason normal.