### PR TITLE
Run the reboot in another process to avoid hang

### DIFF
--- a/lib/nerves_firmware_ssh/handler.ex
+++ b/lib/nerves_firmware_ssh/handler.ex
@@ -169,7 +169,10 @@ defmodule Nerves.Firmware.SSH.Handler do
   defp run_commands([:reboot | rest], data, state) do
     _ = Logger.debug("nerves_firmware_ssh: rebooting...")
     :ssh_connection.send(state.cm, state.id, "Rebooting...\n")
-    Nerves.Runtime.reboot()
+
+    # Run the reboot in another process so that this one can completely and
+    # nicely shut down the ssh connection.
+    spawn(fn -> Nerves.Runtime.reboot() end)
 
     new_state = %{state | commands: rest}
     run_commands(rest, data, new_state)


### PR DESCRIPTION
Firmware uploads would sometimes hang due to the TCP connection not
being properly shutdown. This was due to the ssh handler not returning and
closing the socket before the reboot made it impossible.

Nerves.Runtime.reboot intentionally does not return. The fix, then, is to
run the reboot in a separate process so that ssh handling process can
return and properly close the socket.

While it's conceivable that packet losses and unfavorable scheduling
could still reboot the system before ssh properly closes it, this seems
unlikely and after this fix, I couldn't reproduce the issue on a device
that would demonstrate the problem 90%+ of the time.