### PR TITLE
Remove _ = on all Logger calls

### DIFF
--- a/lib/nerves_firmware_ssh/fwup.ex
+++ b/lib/nerves_firmware_ssh/fwup.ex
@@ -53,7 +53,7 @@ defmodule Nerves.Firmware.SSH.Fwup do
         :ok
       rescue
         ArgumentError ->
-          _ = Logger.info("Port.command ArgumentError race condition detected and handled")
+          Logger.info("Port.command ArgumentError race condition detected and handled")
           :error
       end
 
@@ -68,14 +68,14 @@ defmodule Nerves.Firmware.SSH.Fwup do
 
       [response, <<status>>] ->
         # fwup exited with status
-        _ = Logger.info("fwup exited with status #{status}")
+        Logger.info("fwup exited with status #{status}")
         send(port, {self(), :close})
         :ssh_channel.cast(state.cm, {:fwup_data, response})
         :ssh_channel.cast(state.cm, {:fwup_exit, status})
 
       [response, other] ->
         # fwup exited without status
-        _ = Logger.info("fwup exited improperly: #{inspect(other)}")
+        Logger.info("fwup exited improperly: #{inspect(other)}")
         send(port, {self(), :close})
         :ssh_channel.cast(state.cm, {:fwup_data, response})
     end
@@ -84,19 +84,19 @@ defmodule Nerves.Firmware.SSH.Fwup do
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
-    _ = Logger.info("fwup exited with status #{status} without handshaking")
+    Logger.info("fwup exited with status #{status} without handshaking")
     :ssh_channel.cast(state.cm, {:fwup_exit, status})
     {:noreply, %{state | port: nil}}
   end
 
   def handle_info({port, :closed}, %{port: port} = state) do
-    _ = Logger.info("fwup port was closed")
+    Logger.info("fwup port was closed")
     :ssh_channel.cast(state.cm, {:fwup_exit, 0})
     {:noreply, %{state | port: nil}}
   end
 
   def handle_info({:DOWN, _, :process, cm, _reason}, %{cm: cm, port: port} = state) do
-    _ = Logger.info("firmware ssh handler exited before fwup could finish")
+    Logger.info("firmware ssh handler exited before fwup could finish")
     send(port, {self(), :close})
     {:stop, :normal, state}
   end

--- a/lib/nerves_firmware_ssh/handler.ex
+++ b/lib/nerves_firmware_ssh/handler.ex
@@ -24,7 +24,7 @@ defmodule Nerves.Firmware.SSH.Handler do
   end
 
   def handle_msg({:ssh_channel_up, channel_id, connection_manager}, state) do
-    _ = Logger.debug("nerves_firmware_ssh: new connection")
+    Logger.debug("nerves_firmware_ssh: new connection")
     {:ok, %{state | id: channel_id, cm: connection_manager}}
   end
 
@@ -80,7 +80,7 @@ defmodule Nerves.Firmware.SSH.Handler do
   end
 
   def terminate(_reason, _state) do
-    _ = Logger.debug("nerves_firmware_ssh: connection terminated")
+    Logger.debug("nerves_firmware_ssh: connection terminated")
     :ok
   end
 
@@ -167,7 +167,7 @@ defmodule Nerves.Firmware.SSH.Handler do
   end
 
   defp run_commands([:reboot | rest], data, state) do
-    _ = Logger.debug("nerves_firmware_ssh: rebooting...")
+    Logger.debug("nerves_firmware_ssh: rebooting...")
     :ssh_connection.send(state.cm, state.id, "Rebooting...\n")
 
     # Run the reboot in another process so that this one can completely and
@@ -179,7 +179,7 @@ defmodule Nerves.Firmware.SSH.Handler do
   end
 
   defp maybe_fwup(%{fwup: nil} = state) do
-    _ = Logger.debug("nerves_firmware_ssh: starting fwup...\n")
+    Logger.debug("nerves_firmware_ssh: starting fwup...\n")
     :ssh_connection.send(state.cm, state.id, "Running fwup...\n")
     {:ok, new_fwup} = Fwup.start_link(self())
     %{state | fwup: new_fwup}


### PR DESCRIPTION
Elixir 1.10's Logger calls only return :ok now, so the return value no
longer needs to be ignored to make Dialyzer happy.