### PR TITLE
Handle a normal exit of the send_data process in the mix upload task

### DIFF
--- a/lib/mix/tasks/upload.ex
+++ b/lib/mix/tasks/upload.ex
@@ -157,6 +157,9 @@ defmodule Mix.Tasks.Upload do
       {^port, {:exit_status, status}} ->
         Mix.raise("ssh failed with status #{status}")
 
+      {:EXIT, _, :normal} ->
+        port_read(port)
+
       {:EXIT, ^port, reason} ->
         Mix.raise("""
         Unexpected exit from ssh (#{inspect(reason)})


### PR DESCRIPTION
This PR fixes an error that was being raised when trying to flash a RPi0-based device:

```text
$ MIX_TARGET=keybow mix upload xebow.local

Running fwup...
fwup: Upgrading partition A
 96% [==================================  ] 34.26 MB in / 36.41 MB out**
(Mix) Unexpected message received: {:EXIT, #PID<0.978.0>, :normal}
```

`{:EXIT, #PID<0.978.0>, :normal}` was being sent from a normal exit of the process being spawned here to send the firmware file:

https://github.com/nerves-project/nerves_firmware_ssh/blob/712f350baa4a20a4936a3390cbc08d7d5ee1b3cf/lib/mix/tasks/upload.ex#L102

This PR adds a handler for that message and continues the `port_read()` loop.