### PR TITLE
Add note that this is included by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ set of devices all at once.
 
 ## Installation
 
+> NOTE: If you created your project with `mix nerves.new` then
+> nerves_firmware_ssh is already installed and configured
+
 First, add `nerves_firmware_ssh` to your list of dependencies in `mix.exs`:
 
 ```elixir


### PR DESCRIPTION
In the past I've started installing and configuring nerves_firmware_ssh only to realize that it was already properly installed and configured (and I just needed to adjust the configuration instead)